### PR TITLE
Protocol Grammar/Typos Review sections 00-04

### DIFF
--- a/00-Abstract.md
+++ b/00-Abstract.md
@@ -2,7 +2,7 @@
 
 We propose a new version of the Stratum Protocol (Stratum Version 2 or Sv2) for cryptocurrency mining pools to improve scaling, security, decentralization, and data transfer efficiency.
 
-Stratum Version 1 was not designed to operate at the scale of current cryptocurrency mining pools. Communications are unencrypted, unoptimized, and resticts block template creators, who determine a new block's transaction set, to pool operators.
+Stratum Version 1 was not designed to operate at the scale of current cryptocurrency mining pools. Communications are unencrypted & unoptimized, and v1 resticts block template creators, who determine a new block's transaction set, to pool operators.
 
 Stratum v2 optimizes network communications, offers by-default encryption using the NOISE protocol, and decentralizes block template creation to end mining device operators.
 
@@ -10,4 +10,4 @@ We selected tradeoffs in the protocol's design optimizing for scalability, secur
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC2119.
 
-We keep the name "Stratum" recognizing that this is an upgrade of the widespread protocol version 1: this protocol improves on the design of v1, allows for v1 <-> v2 compatible proxy communication, and maintains the fundamental entity relationships used in Stratum v1.
+We keep the name "Stratum" recognizing that this is an upgrade to Stratum version 1: this protocol improves on the design of v1, allows for v1 <-> v2 compatible proxy communication, and maintains the fundamental entity relationships used in Stratum v1.

--- a/00-Abstract.md
+++ b/00-Abstract.md
@@ -1,12 +1,13 @@
 # 0. Abstract
-The current stratum protocol (v1) is used prevalently throughout the cryptocurrency mining industry today, but it was never intended nor designed to be an industry standard.   
 
-This document proposes a new version of stratum protocol that addresses scaling and quality issues of the previous version, focusing on more efficient data transfers (i.e. distribution of mining jobs and result submissions) as well as increased security.
+We propose a new version of the Stratum Protocol (Stratum Version 2 or Sv2) for cryptocurrency mining pools to improve scaling, security, decentralization, and data transfer efficiency.
 
-Additionally, the redesigned protocol includes support for transaction selection by the miners themselves, as opposed to the current version of the protocol in which only the pool operators can determine a new block’s transaction set.
+Stratum Version 1 was not designed to operate at the scale of current cryptocurrency mining pools. Communications are unencrypted, unoptimized, and resticts block template creators, who determine a new block's transaction set, to pool operators.
 
-There are some trade offs necessary to make the protocol scalable and relatively simple, which will be addressed in the detailed discussions below.
+Stratum v2 optimizes network communications, offers by-default encryption using the NOISE protocol, and decentralizes block template creation to end mining device operators.
+
+We selected tradeoffs in the protocol's design optimizing for scalability, security, and decentralization. We discuss the design choices in detail in the folllowing section.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC2119.
 
-We keep the name "Stratum" so that people will recognize that this is an upgrade of the widespread protocol version 1, with the hope that it will help gather support for the new version more easily. 
+We keep the name "Stratum" recognizing that this is an upgrade of the widespread protocol version 1: this protocol improves on the design of v1, allows for v1 <-> v2 compatible proxy communication, and maintains the fundamental entity relationships used in Stratum v1.

--- a/01-Motivation.md
+++ b/01-Motivation.md
@@ -1,14 +1,15 @@
 # 1. Motivation
-Stratum protocol v1 is JSON-based and lacks cryptographic authentication, making it slower, heavier, and less secure than it can be considering the alternatives available today.
-Given the cryptocurrency mining industry’s continued maturation and growth, it’s necessary to address v1’s deficiencies and move to a more efficient solution with a precise definition.
 
-One of the primary motivations of the new protocol is to reduce the amount and respective size of data transfers between miners, proxies, and pool operators to an absolute minimum.
-This will enable stratum servers to use the saved bandwidth for higher submission rates, thus yielding a reduced variance in hash rate (and in turn in miner payouts).
+Stratum v1 network communication uses a plaintext JSON RPC without cryptographic authentication. V1's JSON design decision allowed for human readability at the cost of security and data efficiency. It is slower, heavier, and less secure than a protocol optimized for computer communication using modern networking techniques.
 
-To increase efficiency further, we will enable a simplified mode for end mining devices which completely eliminates the need for extranonce and Merkle path handling (i.e. any coinbase modification on downstream machines).
-This mode, called header-only mining, makes computations simpler for miners and work validation much lighter on the server side.
-Furthermore, header-only mining reduces the cost of future changes to the Bitcoin protocol, as mining firmware and protocols do not need to be upgraded in conjunction with full nodes.
+We find it necessary to address v1's security deficiencies as the Bitcoin mining industry maturates and grows, and to precisely define the design goals of mining entities' communication protocols.
 
-In terms of security, another important improvement to make is hardening the protocol against man-in-the-middle attacks by providing a way for mining devices to verify the integrity of the assigned mining jobs and other commands.
+Stratum v2 minimizes the amount, and respective size, of data transfers between miners, proxies, and pool operators. Faster, more efficient communication means higher submission rates and reduced variance in hash rate (in turn, miner payouts).
 
-Last but not the least, this protocol strives to allow downstream nodes to choose mining jobs and efficiently communicate them to upstream nodes to reduce power currently held by mining pools (block version selection, transaction selection). This should be possible without harming public pool business models or otherwise leading to more centralization in another area of the mining industry. 
+We create a simplified mining mode, 'header-only mining', for end-mining devices by eliminating extranonce, Merkle path handling, and any other coinbase modification on downstream machines.
+
+Header-only mining allows for further specialization of end-mining machines, moving coinbase modification upstream to a stratum server. It reduces the cost of future changes to the Bitcoin protocol; firmware and protocols for end-mining devices can upgrade independently of upgrades to full nodes.
+
+Stratum v2 introduces by-default encryption and authentication using the NOISE protocol, hardening the protocol against man-in-the-middle attacks.
+
+Finally, Stratum v2 allows downstream miners and mining farms themselves to choose mining jobs, select transactions, build block templates, and efficiently communicate them to upstream nodes. Decentralizing block template creation makes the Bitcoin network more robust, and integrating this change into the Stratum protocol itself allows for decentralization without modifying/harming public pool business models or otherwise leading to more centralization in another area of the mining industry.

--- a/03-Protocol-Overview.md
+++ b/03-Protocol-Overview.md
@@ -1,70 +1,61 @@
 # 3. Protocol Overview
+
 There are technically four distinct (sub)protocols needed in order to fully use all of the features proposed in this document:
 
 1. **Mining Protocol**  
-    The main protocol used for mining and the direct successor of Stratum v1.
-    A mining device uses it to communicate with its upstream node, pool, or a proxy.
-    A proxy uses it to communicate with a pool (or another proxy).
-    This protocol needs to be implemented in all scenarios.
-    For cases in which a miner or pool does not support transaction selection, this is the only protocol used.
+   Direct successor to Stratum v1. A mining device uses this main protocol to communicate with its upstream node, pool, or proxy. A proxy uses it to communicate with a pool (or another proxy). Must be implemented in all scenarios. Only protocol used if a miner/pool does not support transaction selection.
 
 2. **Job Negotiation Protocol**  
-    Used by a miner (a whole mining farm) to negotiate a block template with a pool.
-    Results of this negotiation can be re-used for all mining connections to the pool to reduce computational intensity.
-    In other words, a single negotiation can be used by an entire mining farm or even multiple farms with hundreds of thousands of devices, making it far more efficient.
-    This is separate to allow pools to terminate such connections on separate infrastructure from mining protocol connections (i.e. share submissions).
-    Further, such connections have very different concerns from share submissions - work negotiation likely requires, at a minimum, some spot-checking of work validity, as well as potentially substantial rate-limiting (without the inherent rate-limiting of share difficulty).
+   Miners (or mining farms) negotiate block templates with pool. Pool can reuse negotiation outcomes across all end-miner connections to reduce computational intensity. A single negotiation can multicast to multiple farms with hundreds of thousands of devices.
+   Separating job negotiation as a sub-protocol lets pools terminate negotiation connections independently of mining protocol connections (i.e. share submissions).
+   Work negotiation likely requires, at minimum, validity spot-checks and (potentially) rate-limiting.
 
 3. **Template Distribution Protocol**  
-   A similarly-framed protocol for getting information about the next block out of Bitcoin Core.
-   Designed to replace `getblocktemplate` with something much more efficient and easy to implement for those implementing other parts of Stratum v2.
+   Fetch next block from Bitcoin Core.
+   Replaces `getblocktemplate` with more efficient protocol (and is easier to implement in conjunction with other Stratum v2 modules).
 
 4. **Job Distribution Protocol**  
-   Simple protocol for passing newly-negotiated work to interested nodes - either proxies or miners directly.
-   This protocol is left to be specified in a future document, as it is often unnecessary due to the Job Negotiation role being a part of a larger Mining Protocol Proxy.
+   Pass newly-negotiated work to interested nodes - via proxy or directly to miners.
+   Specifications for this sub-protocol fall outside the scope of this document.
 
-
-Meanwhile, there are five possible roles (types of software/hardware) for communicating with these protocols.
+Five roles (types of software/hardware) for communicating between & among these protocols:
 
 1. **Mining Device**  
-   The actual device computing the hashes. This can be further divided into header-only mining devices and standard mining devices, though most devices will likely support both modes.
+   Produces hashes. Further subdivided into 'header-only' mining devices & 'standard' mining devices. (Most devices will likely support both modes.)
 
 2. **Pool Service**  
-   Produces jobs (for those not negotiating jobs via the Job Negotiation Protocol), validates shares, and ensures blocks found by clients are propagated through the network (though clients which have full block templates MUST also propagate blocks into the Bitcoin P2P network).
+   Produces jobs (or relays Job Negotiation Protocol outcomes), validates shares, & propagates clients' found blocks through the network (though clients which have full block templates MUST also propagate blocks into the Bitcoin P2P network).
 
 3. **Mining Proxy (optional)**  
-   Sits in between Mining Device(s) and Pool Service, aggregating connections for efficiency.
-   May optionally provide additional monitoring, receive work from a Job Negotiator and use custom work with a pool, or provide other services for a farm.
+   Sits between Mining Device(s) and Pool Service, aggregating connections for efficiency.
+   Optionally provides additional monitoring, receives work from a Job Negotiator, uses custom work with a pool, or provides other services for a farm.
 
 4. **Job Negotiator (optional)**  
-   Receives custom block templates from a Template Provider and negotiates use of the template with the pool using the Job Negotiation Protocol.
-   Further distributes the jobs to Mining Proxy (or Proxies) using the Job Distribution Protocol. This role will often be a built-in part of a Mining Proxy.
+   Receives custom block templates from Template Provider and negotiates template use with the pool per Job Negotiation Protocol.
+   Further distributes jobs to Mining Proxy (or Proxies) via the Job Distribution Protocol. Role optionally built into the Mining Proxy.
 
 5. **Template Provider**  
-   Generates custom block templates to be passed to the Job Negotiator for eventual mining.
-   This is usually just a Bitcoin Core full node (or possibly some other node implementation).
+   Generates custom block templates,, passed to Job Negotiator for eventual mining.
+   (Usually a Bitcoin Core full node, or some other node implementation.)
 
+The Mining Protocol communicates between Mining Device and Pool Service, Mining Device and Mining Proxy, Mining Proxy and Mining Proxy, or Mining Proxy and Pool Service.
 
-The Mining Protocol is used for communication between a Mining Device and Pool Service, Mining Device and Mining Proxy, Mining Proxy and Mining Proxy, or Mining Proxy and Pool Service.
+The Job Negotiation Protocol communicates between Job Negotiator and Pool Service.
 
-The Job Negotiation Protocol is used for communication between a Job Negotiator and Pool Service.
+The Template Distribution Protocol communicates between Job Negotiator and Template Provider.
 
-The Template Distribution Protocol is used for communication between a Job Negotiator and Template Provider.
+The Job Distribution Protocol communicates between Job Negotiator and a Mining Proxy.
 
-The Job Distribution Protocol is used for communication between a Job Negotiator and a Mining Proxy.
+Software/hardware can fill multiple roles (e.g. Mining Proxy is often both a Mining Proxy and a Job Negotiator, and may occasionally further contain a Template Provider as a full node process on the same device).
 
-One type of software/hardware can fulfill more than one role (e.g. a Mining Proxy is often both a Mining Proxy and a Job Negotiator and may occasionally further contain a Template Provider in the form of a full node on the same device).
-
-Each sub-protocol is based on the same technical principles and requires a connection oriented transport layer, such as TCP.
-In specific use cases, it may make sense to operate the protocol over a connectionless transport with FEC or local broadcast with retransmission.
-However, that is outside of the scope of this document.
+Each sub-protocol employs the same technical principles and requires a connection oriented transport layer like TCP.
+Can, depending on circumstance and requirements, operate the protocol over a connectionless transport with FEC or local broadcast with retransmission. Such a configuration is outside of the scope of this document.
 The minimum requirement of the transport layer is to guarantee ordered delivery of the protocol messages.
 
-
 ## 3.1 Data Types Mapping
-Message definitions use common data types described here for convenience.
-Multibyte data types are always serialized as little-endian.
 
+Message definitions use common data types described below.
+Multibyte data types are always serialized as little-endian.
 
 ```
 +---------------+---------------------------------+--------------------------------------------------------------------+
@@ -72,7 +63,7 @@ Multibyte data types are always serialized as little-endian.
 +---------------+---------------------------------+--------------------------------------------------------------------+
 | BOOL          | 1                               | Boolean value. Encoded as an unsigned 1-bit integer, True = 1,     |
 |               |                                 | False = 0 with 7 additional padding bits in the high positions.    |
-|               |                                 |                                                                    |                                                                                                                                                                                                                                                                                              |
+|               |                                 |                                                                    |
 |               |                                 | Recipients MUST NOT interpret bits outside of the least            |
 |               |                                 | significant bit. Senders MAY set bits outside of the least         |
 |               |                                 | significant bit to any value without any impact on meaning. This   |
@@ -125,95 +116,99 @@ Multibyte data types are always serialized as little-endian.
 +---------------+---------------------------------+--------------------------------------------------------------------+
 ```
 
-
 ## 3.2 Framing
+
 The protocol is binary, with fixed message framing.
-Each message begins with the extension type, message type, and message length (six bytes in total), followed by a variable length message.
-The message framing is outlined below:
+Each message begins with 6 bytes:
+
+- extension type (2-bytes)
+- message type (1-byte)
+- message length (3-bytes)
+
+Followed by a variable length message.
+
+**Message Framing Outline**
 
 ```
 +----------------+-------------+---------------------------------------------------------------------------------------+
 | Protocol Type  | Byte Length | Description                                                                           |
 +----------------+-------------+---------------------------------------------------------------------------------------+
-| extension_type | U16         | Unique identifier of the extension describing this protocol message.                  |
+| extension_type | U16         | Unique extension identifier describing this protocol message.                         |
 |                |             |                                                                                       |
-|                |             | Most significant bit (i.e.bit 15, 0-indexed, aka channel_msg) indicates a message     |
-|                |             | which is specific to a channel, whereas if the most significant bit is unset, the     |
-|                |             | message is to be interpreted by the immediate receiving device.                       |
+|                |             | Most significant bit (MSB) (i.e.bit 15, 0-indexed, aka channel_msg) indicates         |
+|                |             | a channel specific message. If unset, the message is interpreted by the immediate     |
+                 |             | receiving device.                                                                     |
 |                |             |                                                                                       |
-|                |             | Note that the channel_msg bit is ignored in the extension lookup, i.e.an              |
-|                |             | extension_type of 0x8ABC is for the same "extension" as 0x0ABC.                       |
+|                |             | Note: the channel_msg bit is ignored in the extension lookup,                         |
+|                |             |       i.e. an extension_type of 0x8ABC is for the same "extension" as 0x0ABC.         |
 |                |             |                                                                                       |
-|                |             | If the channel_msg bit is set, the first four bytes of the payload field is a U32     |
-|                |             | representing the channel_id this message is destined for (these bytes are repeated in |
-|                |             | the message framing descriptions below).                                              |
+|                |             | If channel_msg bit set, first four bytes of payload is a U32 representing the         |
+|                |             | message's destination channel-id.                                                     |
+|                |             | (These bytes are repeated in the message framing descriptions below.)                 |
 |                |             |                                                                                       |
-|                |             | Note that for the Job Negotiation and Template Distribution Protocols the channel_msg |
-|                |             | bit is always unset.                                                                  |
+|                |             | Note: channel_msg bit always unset for the Job Negotiation and Template               |
+|                |             |       Distribution Protocols.                                                         |
 +----------------+-------------+---------------------------------------------------------------------------------------+
-| msg_type       | U8          | Unique identifier of the extension describing this protocol message                   |
+| msg_type       | U8          | Unique extension identifier describing this protocol message.                         |
 +----------------+-------------+---------------------------------------------------------------------------------------+
-| msg_length     | U24         | Length of the protocol message, not including this header                             |
+| msg_length     | U24         | Length of the protocol message (excluding this header)                                |
 +----------------+-------------+---------------------------------------------------------------------------------------+
-| payload        | BYTES       | Message-specific payload of length msg_length. If the MSB in extension_type           |
-|                |             | (the channel_msg bit) is set the first four bytes are defined as a U32 "channel_id",  |
-|                |             | though this definition is repeated in the message definitions below and these 4 bytes |
-|                |             | are included in msg_length.                                                           |
+| payload        | BYTES       | Message-specific payload of length msg_length. If MSB in extension_type               |
+|                |             | (the channel_msg bit) is set, first 4 bytes defined as a U32 "channel_id",            |
+|                |             | definition is repeated in the message definitions below.                              |
+|                |             | These 4 bytes are included in msg_length.                                             |
 +----------------+-------------+---------------------------------------------------------------------------------------+
 
 ```
 
-
 ## 3.3 Protocol Security
-Stratum V2 employs a type of encryption scheme called AEAD (authenticated encryption with associated data) to address the security aspects of all communication that occurs between clients and servers.
-This provides both confidentiality and integrity for the ciphertexts (i.e. encrypted data) being transferred, as well as providing integrity for associated data which is not encrypted.
-Prior to opening any Stratum V2 channels for mining, clients MUST first initiate the cryptographic session state that is used to encrypt all messages sent between themselves and servers.
-Thus, the cryptographic session state is independent of V2 messaging conventions.
 
-At the same time, this specification proposes optional use of a particular handshake protocol based on the **[Noise Protocol framework](https://noiseprotocol.org/noise.html)**.
-The client and server establish secure communication using Diffie-Hellman (DH) key agreement, as described in greater detail in the Authenticated Key Agreement Handshake section below.
+Stratum V2 uses the AEAD encryption scheme (authenticated encryption with associated data) to secure client<->server communication. AEAD provides confidentiality & integrity guarantees for both encrypted ciphertexts and unencrypted associated data.
+Prior to opening Stratum V2 mining channels, clients MUST initiate the cryptographic session state used to encrypt client<->server messages. The cryptographic session state is independent of V2 messaging conventions.
 
-Using the handshake protocol to establish secured communication is **optional** on the local network (e.g. local mining devices talking to a local mining proxy).
-However, it is **mandatory** for remote access to the upstream nodes, whether they be pool mining services, job negotiating services or template distributors.
+This specification simultaneously proposes optional use of of the **[Noise Protocol framework](https://noiseprotocol.org/noise.html)** handshake.
+Client and server establish secure communication using Diffie-Hellman (DH) key exchange, as described in the **Authenticated Key Agreement Handshake** section below.
 
+The handshake protocol for secured communication is **optional** on the local network (i.e. local mining devices talking to a local mining proxy).
+The handshake is **mandatory** for remote access to upstream nodes (pool mining services, job negotiating services or template distributors).
 
 ### 3.3.1 Motivation for Authenticated Encryption with Associated Data
-Data transferred by the mining protocol MUST not provide adversary information that they can use to estimate the performance of any particular miner.
-Any intelligence about submitted shares can be directly converted to estimations of a miner’s earnings and can be associated with a particular username.
-This is unacceptable privacy leakage that needs to be addressed.
 
+Data transferred by the mining protocol MUST NOT provide an adversary information to estimate any particular miner's performance.
+Any submitted shares information allows miner’s earnings estimations, and can be mapped to a particular username.
+This is an unacceptable privacy leak.
 
 ### 3.3.2 Motivation for Using the Noise Protocol Framework
-The reasons why Noise Protocol Framework has been chosen are listed below:
 
-- The Framework pushes to use new, modern cryptography.
-- The Framework provides a formalism to describe the handshake protocol that can be verified.
-- There is no legacy overhead.
-- It is difficult to get wrong.
-- Noise Explorer provides code generators for popular programming languages (e.g. Go, Rust).
-- We can specify no flexibility (i.e. fewer degrees of freedom), helping ensure standardization of the supported ciphersuite(s).
-- A custom certificate scheme is now possible (no need to use x509 certificates).
-
+- The Noise Framework pushes to use modern cryptography.
+- The Noise Framework provides formal, verifiable handshake protocol description.
+- No legacy overhead.
+- Difficult to get wrong.
+- Noise Explorer provides code generators for popular programming languages.
+- Can specify no flexibility (i.e. fewer degrees of freedom), ensuring standardized ciphersuite(s) support.
+- Custom certificate scheme possible (no need to use x509 certificates).
 
 ### 3.3.3 Authenticated Key Agreement Handshake
-The handshake chosen for the authenticated key exchange is **`Noise_NX_25519_<encryption-algorithm>_BLAKE2s`** as it
-provides authentication of the server side and does not require authentication of the initiator (client).
-Server authentication is achieved implicitly via a series of Elliptic-Curve Diffie-Hellman (ECDH) operations followed by a MAC check.
+
+The **`Noise_NX_25519_<encryption-algorithm>_BLAKE2s`** handshake provides server-side authentication & does not require initiator (client) authentication.
+We achieve server authentication via a series of Elliptic-Curve Diffie-Hellman (ECDH) operations, followed by a MAC check.
 
 The authenticated key agreement (`Noise NX`) is performed in three distinct steps (acts).
-1. Encryption Algorithm negotiation: Initiator provides a list of supported encryption algorithms to the responder; the list
-   is mixed into the hash digest on noise Symmetric State initialization as a noise Prologue. Responder mixes the received
-   list to thier hash digest (note that if responder uses different prologue than initiator, then noise handshake fails)
-   and sends the chosen algorithm to the initiator
-2. Ephemeral and static key exchange followed by ECDH: keying material is sent to the other party; an ECDH is performed,
-   with the result mixed into the current set of encryption keys (`ck` the chaining key and `k` the encryption key)
-3. Server authentication with Signature Noise Message: Initiator verifies the SIGNATURE_NOISE_MESSAGE that it received
-   in previous step as a handshake payload
 
-The mixing of ECDH outputs into a hash digest forms an incremental DoubleDH handshake.
+1. Encryption Algorithm Negotiation: Initiator provides a list of supported encryption algorithms to Responder; list
+   is mixed into the hash digest on noise Symmetric State initialization as a noise Prologue. Responder mixes received list to thier hash digest and sends chosen algorithm to the initiator.
+   (Note: if Responder uses different prologue than Initiator, noise handshake fails.)
+2. Ephemeral & Static Key Exchange, followed by ECDH: keying material sent to other party; pertform ECDH,
+   result mixed into current set of encryption keys.
+   `ck == chaining key`
+   `k == encryption key`
+3. Server Authentication with Signature Noise Message: Initiator verifies received SIGNATURE_NOISE_MESSAGE in previous step as a handshake payload.
 
-Using the language of the Noise Protocol, **`e`** and **`s`** (both public keys with `**e**` being the **ephemeral key** and `**s**` being the **static key**) indicate possibly encrypted keying material, and **`es`**, **`ee`**, and **`se`** each indicate an ECDH operation between two keys.
-The handshake is laid out as follows:
+ECDH outputs mix into a hash digest forms an 'incremental DoubleDH handshake'.
+
+Per Noise Protocol language, **`e`** and **`s`** (both public keys where **`e == ephemeral key`** and `**s == static key**`) indicate possibly encrypted keying material, and **`es`**, **`ee`**, and **`se`** each indicate an ECDH operation between two keys.
+
+**Handshake Protocol**
 
 ```
    Noise_NX:
@@ -223,17 +218,17 @@ The handshake is laid out as follows:
        <- e, ee, s, es, SIGNATURE_NOISE_MESSAGE
 ```
 
-The last handshake message is followed by a `SIGNATURE_NOISE_MESSAGE`.
-Using this additional message allows us to authenticate the stratum server to the downstream node.
-The certificate implements a simple 2 level public key infrastructure. 
+Last handshake message followed by a `SIGNATURE_NOISE_MESSAGE`.
+This additional message authenticates the stratum server to the downstream node.
+The certificate implements a simple 2-level public key infrastructure.
 
-The main idea is that each server operator has a long-term authority keypair and each stratum-server is equipped with a
-certificate signed by the authority private key that confirms its identity to the clients.
-The certificate has time limited validity and is signed by the central pool authority.
+Each server operator has a long-term authority keypair, and each stratum-server has a certificate, signed by the authority private key, authenticating itself to clients.
+The certificate has time-limited validity, and is signed by the central pool authority.
 
 ### 3.3.4 Noise message framing
-Every message that is sent over the wire as part of a handshake or already an established session is prefixed with payload
-length as a two-bytes little endian u16 number
+
+Every message sent over the wire for a handshake or established session is prefixed with payload
+length (two-bytes, little-endian)
 
 ```
 +----------------------------+-------------------------------------------------------------------+
@@ -241,13 +236,12 @@ length as a two-bytes little endian u16 number
 +----------------------------+-------------------------------------------------------------------+
 ```
 
-
 ### 3.3.5 Signature Noise Message
-This message uses the same serialization format as other stratum messages.
-It contains serialized:
+
+Message serialized similarly to other stratum messages:
 
 - Server Certificate header (`version`, `valid_from` and `not_not_valid_after` fields)
-- ED25519 signature that can be verified by the Pool Authority Public key and the client can reconstruct the full Certificate from its "`s`" and this header and authenticate the server. 
+- ED25519 signature verifiable by the Pool Authority Public key. Client can reconstruct the full Certificate from its "`s`" and this header to authenticate the server.
 
 ```
 +-----------------+-----------+----------------------------------------------------------------------------------------+
@@ -255,18 +249,17 @@ It contains serialized:
 +-----------------+-----------+----------------------------------------------------------------------------------------+
 | version         | U16       | Version of the certificate format                                                      |
 +-----------------+-----------+----------------------------------------------------------------------------------------+
-| valid_from      | U32       | Validity start time (unix timestamp)                                                   |
+| valid_from      | U32       | Validity start time (UNIX timestamp)                                                   |
 +-----------------+-----------+----------------------------------------------------------------------------------------+
-| not_valid_after | U32       | Signature is invalid after this point in time (unix timestamp)                         |
+| not_valid_after | U32       | Signature invalid after this time (UNIX timestamp)                                     |
 +-----------------+-----------+----------------------------------------------------------------------------------------+
 | signature       | SIGNATURE | ED25519 signature                                                                      |
 +-----------------+-----------+----------------------------------------------------------------------------------------+
 ```
 
-
 ### 3.3.6 Certificate Format
-Stratum server certificates have the following layout.
-The signature is  constructed over the fields marked for signing after serialization using Stratum protocol binary serialization format.
+
+Signature constructed over fields marked for signing after serialization using Stratum protocol binary serialization format.
 
 ```
 +----------------------+-----------+--------------------------------------------------------------------+--------------+
@@ -274,68 +267,74 @@ The signature is  constructed over the fields marked for signing after serializa
 +----------------------+-----------+--------------------------------------------------------------------+--------------+
 | version              | U16       | Version of the certificate format                                  | YES          |
 +----------------------+-----------+--------------------------------------------------------------------+--------------+
-| valid_from           | U32       | Validity start time (unix timestamp)                               | YES          |
+| valid_from           | U32       | Validity start time (UNIX timestamp)                               | YES          |
 +----------------------+-----------+--------------------------------------------------------------------+--------------+
-| not_valid_after      | U32       | Signature is invalid after this pont in time (unix timestamp)      | YES          |
+| not_valid_after      | U32       | Signature invalid after this time (UNIX timestamp)                 | YES          |
 +----------------------+-----------+--------------------------------------------------------------------+--------------+
-| authority_public_key | PUBKEY    | Public key used for verfication of the signature                   | NO           |
+| authority_public_key | PUBKEY    | Public key for signature verification                              | NO           |
 +----------------------+-----------+--------------------------------------------------------------------+--------------+
 | signature            | SIGNATURE | ED25519                                                            | NO           |
 +----------------------+-----------+-----------------------------------------------------------------------------------+
 ```
 
-
 ### 3.3.6 URL Scheme and Pool Authority Key
-Downstream nodes that want to use the above outlined security scheme need to have configured the **Pool Authority Key** of the pool that they intend to connect to.
-The key can be embedded into the mining URL as part of the path.
+
+To use the security scheme outlined above, downstream nodes must configure the **Pool Authority Key** for intended pool connection.
+Embed key into the mining URL as part of the path.
 E.g.:
 
 ```
 stratum2+tcp://thepool.com/u95GEReVMjK6k5YqiSFNqqTnKU4ypU2Wm8awa6tmbmDmk1bWt
 ```
 
-The "**`u95GEReVMjK6k5YqiSFNqqTnKU4ypU2Wm8awa6tmbmDmk1bWt`**" is the public key in [base58-check](https://en.bitcoin.it/wiki/Base58Check_encoding) encoding.
-It is provided by the target pool and communicated to its users via a trusted channel.
-At least, it can be published on the pool's public website.
-
+"**`u95GEReVMjK6k5YqiSFNqqTnKU4ypU2Wm8awa6tmbmDmk1bWt`**" is the public key in [base58-check](https://en.bitcoin.it/wiki/Base58Check_encoding) encoding.
+Provided by target pool, communicated to its users via a trusted channel.
+(Can be published on the pool's public website.)
 
 ## 3.4 Reconnecting Downstream Nodes
-An upstream stratum node may occasionally request reconnection of its downstream peers to a different host (e.g. due to maintenance reasons, etc.).
+
+An upstream stratum node may occasionally request reconnection of downstream peers to a different host (e.g. maintenance reasons, etc.).
 This request is per upstream connection and affects all open channels towards the upstream stratum node.
 
-After receiving a request to reconnect, the downstream node MUST run the handshake protocol with the new node as long as its previous connection was also running through a secure cryptographic session state.
-
+After receiving a reconnect request, downstream node MUST run the handshake protocol with the new node. (As long as its previous connection was also running through a secure cryptographic session state.)
 
 ## 3.5 Protocol Extensions
-Protocol extensions may be defined by using a non-0 `extension_type` field in the message header (not including the `channel_msg` bit).
-The value used MUST either be in the range `0x4000` - `0x7fff` (inclusive, i.e. have the second-to-most-significant-bit set) denoting an "experimental" extension and not be present in production equipment, or have been allocated for the purpose at [http://stratumprotocol.org](http://stratumprotocol.org).
-While extensions SHOULD have BIPs written describing their full functionality, `extension_type` allocations MAY also be requested for vendor-specific proprietary extensions to be used in production hardware.
-This is done by sending an email with a brief description of the intended use case to the Bitcoin Protocol Development List and extensions@stratumprotocol.org.
-(Note that these contacts may change in the future, please check the latest version of this BIP prior to sending such a request.)
 
-Extensions are left largely undefined in this BIP, however, there are some basic requirements that all extensions must comply with/be aware of.
-For unknown `extension_type`'s, the `channel_msg` bit in the `extension_type` field determines which device the message is intended to be processed on: if set, the channel endpoint (i.e. either an end mining device, or a pool server) is the final recipient of the message, whereas if unset, the final recipient is the endpoint of the connection on which the message is sent.
-Note that in cases where channels are aggregated across multiple devices, the proxy which is aggregating multiple devices into one channel forms the channel’s "endpoint" and processes channel messages.
-Thus, any proxy devices which receive a message with the `channel_msg` bit set and an unknown `extension_type` value MUST forward that message to the downstream/upstream device which corresponds with the `channel_id` specified in the first four bytes of the message payload.
-Any `channel_id` mapping/conversion required for other channel messages MUST be done on the `channel_id` in the first four bytes of the message payload, but the message MUST NOT be otherwise modified.
-If a device is aware of the semantics of a given extension type, it MUST process messages for that extension in accordance with the specification for that extension.
+Defined with a non-0 `extension_type` field in the message header (not including the `channel_msg` bit).
+Value MUST **either**:
 
-Messages with an unknown `extension_type` which are to be processed locally (as defined above) MUST be discarded and ignored.
+- be in the range `0x4000` - `0x7fff` (inclusive, i.e. have the second-to-most-significant-bit set) denoting an "experimental" extension & not be present in production equipment
+- or have been allocated for the purpose at [http://stratumprotocol.org](http://stratumprotocol.org).
+  While extensions SHOULD have BIPs written describing their full functionality, `extension_type` allocations MAY also be requested for vendor-specific proprietary extensions for production hardware.
+  Send an email with a brief description of the intended use case to the Bitcoin Protocol Development List and extensions@stratumprotocol.org.
+  (Note: these contacts may change in the future, please check the latest version of this BIP prior to sending such a request.)
 
-Extensions MUST require version negotiation with the recipient of the message to check that the extension is supported before sending non-version-negotiation messages for it.
-This prevents the needlessly wasted bandwidth and potentially serious performance degradation of extension messages when the recipient does not support them.
+We leave extensions largely undefined in this BIP. Some basic requirements that all extensions must comply with/be aware of:
 
-See `ChannelEndpointChanged` message in Common Protocol Messages for details about how extensions interact with dynamic channel reconfiguration in proxies.
+- For unknown `extension_type`'s, the `channel_msg` bit in the `extension_type` field determines which device the message is intended to be processed on:
+  - If set: the channel endpoint (i.e. either an end mining device, or a pool server) is the final recipient of the message.
+  - If unset, the final recipient is the endpoint of the connection on which the message is sent.
+    (Note: if channels aggregated across multiple devices, the aggregating proxy forms the channel’s "endpoint" and processes channel messages.)
+    Proxy devices receiving a message with `channel_msg` bit set and an unknown `extension_type` MUST forward that message to the downstream/upstream device mapping to the `channel_id` (specified in the first four bytes of the message payload).
+    Any `channel_id` mapping/conversion required for other channel messages MUST be done on the `channel_id` in the first four bytes of the message payload. The message MUST NOT be otherwise modified.
+    If a device is aware of the semantics of a given extension type, it MUST process messages for that extension according to the specification for that extension.
 
+Locally processed messages with unknown `extension_type` (as defined above) MUST be discarded and ignored.
+
+Extensions MUST require version negotiation with the message recipient to check extension support before sending non-version-negotiation messages for it.
+This prevents wasted bandwidth and potentially serious performance degradation of extension messages if unsupported.
+
+See `ChannelEndpointChanged` message in Common Protocol Messages for how extensions interact with dynamic channel reconfiguration in proxies.
 
 ## 3.6 Error Codes
-The protocol uses string error codes.
-The list of error codes can differ between implementations, and thus implementations MUST NOT take any automated action(s) on the basis of an error code.
-Implementations/pools SHOULD provide documentation on the meaning of error codes and error codes SHOULD use printable ASCII where possible.
-Furthermore, error codes MUST NOT include control characters. 
 
-To make interoperability simpler, the following error codes are provided which implementations SHOULD consider using for the given scenarios.
-Individual error codes are also specified along with their respective error messages.
+The protocol uses string error codes. The list of error codes can differ between implementations.
+Implementations MUST NOT take any automated action(s) on the basis of an error code.
+Implementations/pools SHOULD provide documentation on the meaning of error codes and error codes SHOULD use printable ASCII where possible.
+Error codes MUST NOT include control characters.
+
+We provide the following error codes which implementations SHOULD use for simplicity.
+We specify individual error codes with their respective error messages.
 
 - `unknown-user`
 - `too-low-difficulty`
@@ -344,17 +343,21 @@ Individual error codes are also specified along with their respective error mess
 - `unsupported-protocol`
 - `protocol-version-mismatch`
 
-
 ## 3.7 Common Protocol Messages
-The following protocol messages are common across all of the protocols described in this BIP.
 
+Protocol messages common across all protocols described in this BIP.
 
 ### 3.7.1 `SetupConnection` (Client -> Server)
+
 Initiates the connection.
-This MUST be the first message sent by the client on the newly opened connection.
-Server MUST respond with either a `SetupConnection.Success` or `SetupConnection.Error` message.
-Clients that are not configured to provide telemetry data to the upstream node SHOULD set `device_id` to 0-length strings.
-However, they MUST always set vendor to a string describing the manufacturer/developer and firmware version and SHOULD always set `hardware_version` to a string describing, at least, the particular hardware/software package in use.
+MUST be the first message sent by the client on the newly opened connection.
+Server MUST respond with either:
+
+- `SetupConnection.Success`
+- or `SetupConnection.Error` message
+  Clients SHOULD set `device_id` to 0-length strings if not configured to provide upstream node with telemetry data .
+  Clients MUST always set vendor to a string describing the manufacturer/developer and firmware version.
+  Clients SHOULD always set `hardware_version` to a string describing, at least, the particular hardware/software package in use.
 
 ```
 +------------------+-----------+----------------------------------------------------------------------------------------+
@@ -388,10 +391,10 @@ However, they MUST always set vendor to a string describing the manufacturer/dev
 +------------------+-----------+----------------------------------------------------------------------------------------+
 ```
 
-
 ### 3.7.2 `SetupConnection.Success` (Server -> Client)
-Response to `SetupConnection` message if the server accepts the connection.
-The client is required to verify the set of feature flags that the server supports and act accordingly.
+
+Response to `SetupConnection` message if server accepts connection.
+Client MUST verify server's supported feature flags and act accordingly.
 
 ```
 +--------------+-----------+-------------------------------------------------------------------------------------------+
@@ -405,13 +408,13 @@ The client is required to verify the set of feature flags that the server suppor
 +--------------+-----------+-------------------------------------------------------------------------------------------+
 ```
 
-
 ### 3.7.3 `SetupConnection.Error` (Server -> Client)
-When protocol version negotiation fails (or there is another reason why the upstream node cannot setup the connection) the server sends this message with a particular error code prior to closing the connection.
 
-In order to allow a client to determine the set of available features for a given server (e.g. for proxies which dynamically switch between different pools and need to be aware of supported options), clients SHOULD send a SetupConnection message with all flags set and examine the (potentially) resulting `SetupConnection.Error` message’s flags field.
-The Server MUST provide the full set of flags which it does not support in each `SetupConnection.Error` message and MUST consistently support the same set of flags across all servers on the same hostname and port number.
-If flags is 0, the error is a result of some condition aside from unsupported flags.
+When protocol version negotiation fails (or upstream node cannot setup connection) server sends this message with a specific error code prior to closing connection.
+
+Clients SHOULD send a SetupConnection message with all flags set and examine the (potentially) resulting `SetupConnection.Error` message’s flags field. This allows client to determine server's supported feature set (e.g. for proxies which dynamically switch between different pools),
+Server MUST provide the full set of unsupported flags in each `SetupConnection.Error` message and MUST consistently support the same set of flags across all servers on the same hostname and port number.
+If flags == 0, error is some condition aside from unsupported flags.
 
 ```
 +------------+-----------+---------------------------------------------------------------------------------------------+
@@ -419,24 +422,25 @@ If flags is 0, the error is a result of some condition aside from unsupported fl
 +------------+-----------+---------------------------------------------------------------------------------------------+
 | flags      | U32       | Flags indicating features causing an error                                                  |
 +------------+-----------+---------------------------------------------------------------------------------------------+
-| error_code | STR0_255  | Human-readable error code(s), see Error Codes section below                                 |
+| error_code | STR0_255  | Human-readable error code(s) (see Error Codes section below)                                |
 +------------+-----------+---------------------------------------------------------------------------------------------+
 ```
+
 Possible error codes:
 
 - `unsupported-feature-flags`
 - `unsupported-protocol`
 - `protocol-version-mismatch`
 
-
 ### 3.7.4 `ChannelEndpointChanged` (Server -> Client)
-When a channel’s upstream or downstream endpoint changes and that channel had previously sent messages with **`channel_msg`** bitset of unknown `extension_type`, the intermediate proxy MUST send a **`ChannelEndpointChanged`** message.
-Upon receipt thereof, any extension state (including version negotiation and the presence of support for a given extension) MUST be reset and version/presence negotiation must begin again.
+
+When a channel’s upstream or downstream endpoint changes and channel previously sent messages with **`channel_msg`** bitset of unknown `extension_type`, intermediate proxy MUST send a **`ChannelEndpointChanged`** message.
+On receipt, any extension state (including version negotiation and any given extension support) MUST reset version/presence negotiation.
 
 ```
 +------------+-----------+----------------------------------------------------------------------------------------+
 | Field Name | Data Type | Description                                                                            |
 +------------+-----------+----------------------------------------------------------------------------------------+
-| channel_id | U32       | The channel which has changed enpoint                                                  |
+| channel_id | U32       | Changed channel endpoint                                                               |
 +------------+-----------+----------------------------------------------------------------------------------------+
 ```

--- a/03-Protocol-Overview.md
+++ b/03-Protocol-Overview.md
@@ -225,7 +225,7 @@ The certificate implements a simple 2-level public key infrastructure.
 Each server operator has a long-term authority keypair, and each stratum-server has a certificate, signed by the authority private key, authenticating itself to clients.
 The certificate has time-limited validity, and is signed by the central pool authority.
 
-### 3.3.4 Noise message framing
+### 3.3.4 Noise Message Framing
 
 Every message sent over the wire for a handshake or established session is prefixed with payload
 length (two-bytes, little-endian)
@@ -277,7 +277,7 @@ Signature constructed over fields marked for signing after serialization using S
 +----------------------+-----------+-----------------------------------------------------------------------------------+
 ```
 
-### 3.3.6 URL Scheme and Pool Authority Key
+### 3.3.7 URL Scheme and Pool Authority Key
 
 To use the security scheme outlined above, downstream nodes must configure the **Pool Authority Key** for intended pool connection.
 Embed key into the mining URL as part of the path.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Stratum V2 Protocol Specification
+
 This repository contains the Stratum V2 protocol specification.
 
 - [0. Abstract](https://github.com/stratum-mining/sv2-spec/blob/main/00-Abstract.md#0-abstract)
@@ -11,9 +12,10 @@ This repository contains the Stratum V2 protocol specification.
     - [3.3.1 Motivation for Authenticated Encryption with Associated Data](https://github.com/stratum-mining/sv2-spec/blob/main/03-Protocol-Overview.md#331-motivation-for-authenticated-encryption-with-associated-data)
     - [3.3.2 Motivation for Using the Noise Protocol Framework](https://github.com/stratum-mining/sv2-spec/blob/main/03-Protocol-Overview.md#332-motivation-for-using-the-noise-protocol-framework)
     - [3.3.3 Authenticated Key Agreement Handshake](https://github.com/stratum-mining/sv2-spec/blob/main/03-Protocol-Overview.md#333-authenticated-key-agreement-handshake)
-    - [3.3.4 Signature Noise Message](https://github.com/stratum-mining/sv2-spec/blob/main/03-Protocol-Overview.md#334-signature-noise-message)
-    - [3.3.5 Certificate Format](https://github.com/stratum-mining/sv2-spec/blob/main/03-Protocol-Overview.md#335-certificate-format)
-    - [3.3.6 URL Scheme and Pool Authority Key](https://github.com/stratum-mining/sv2-spec/blob/main/03-Protocol-Overview.md#336-url-scheme-and-pool-authority-key)
+    - [3.3.4 Noise Message Framing](https://github.com/stratum-mining/sv2-spec/blob/main/03-Protocol-Overview.md#334-noise-message-framing)
+    - [3.3.5 Signature Noise Message](https://github.com/stratum-mining/sv2-spec/blob/main/03-Protocol-Overview.md#335-signature-noise-message)
+    - [3.3.6 Certificate Format](https://github.com/stratum-mining/sv2-spec/blob/main/03-Protocol-Overview.md#336-certificate-format)
+    - [3.3.7 URL Scheme and Pool Authority Key](https://github.com/stratum-mining/sv2-spec/blob/main/03-Protocol-Overview.md#337-url-scheme-and-pool-authority-key)
   - [3.4 Reconnecting Downstream Nodes](https://github.com/stratum-mining/sv2-spec/blob/main/03-Protocol-Overview.md#34-reconnecting-downstream-nodes)
   - [3.5 Protocol Extensions](https://github.com/stratum-mining/sv2-spec/blob/main/03-Protocol-Overview.md#35-protocol-extensions)
   - [3.6 Error Codes](https://github.com/stratum-mining/sv2-spec/blob/main/03-Protocol-Overview.md#36-error-codes)
@@ -92,6 +94,7 @@ This repository contains the Stratum V2 protocol specification.
   - [9.7 Open Questions / Issues](https://github.com/stratum-mining/sv2-spec/blob/main/09-Discussion.md#97-open-questions--issues)
 
 ## Authors
+
 Pavel Moravec <pavel@braiins.com>  
 Jan Čapek <jan@braiins.com>  
 Matt Corallo <bipstratum@bluematt.me>


### PR DESCRIPTION
I've been cleaning up the spec on my fork as I read through it: removing passive voice, fixing typos, cutting out redundancies, etc. Was careful not to change the function of any technical descriptions and actual specifications, but these 4 files (Abstract, Motivation, Design Goals, and Protocol-Overview) are relatively non-technical (mostly wave tops vs deeper descriptions in the remaining parts of the spec).