### PR TITLE
Template Provider: add new field witness_reserve_value for segwit compliant NewTemplates

### DIFF
--- a/06-Template-Distribution-Protocol.md
+++ b/06-Template-Distribution-Protocol.md
@@ -71,6 +71,13 @@ The primary template-providing function. Note that the `coinbase_tx_outputs` byt
 +-----------------------------+----------------+-----------------------------------------------------------------------+
 | merkle_path                 | SEQ0_255[U256] | Merkle path hashes ordered from deepest                               |
 +-----------------------------+----------------+-----------------------------------------------------------------------+
+| witness_reserve_value       | B0_255         | Optional value when a NewTemplate contains segwit inputs. The witness |
+|                             |                | reserve value is always 32 bytes and is used by Bitcoin for future    |
+|                             |                | extensions. The Template Provider and the downstream device will need |
+|                             |                | to use the witness reserve value as an input along with the witness   |
+|                             |                | root to compute a valid witness commitment                            |
+|                             |                |                                                                       |
++-----------------------------+----------------+-----------------------------------------------------------------------+
 ```
 
 

--- a/06-Template-Distribution-Protocol.md
+++ b/06-Template-Distribution-Protocol.md
@@ -65,7 +65,10 @@ The primary template-providing function. Note that the `coinbase_tx_outputs` byt
 | coinbase_tx_outputs_count   | U32            | The number of transaction outputs included in coinbase_tx_outputs     |
 +-----------------------------+----------------+-----------------------------------------------------------------------+
 | coinbase_tx_outputs         | B0_64K         | Bitcoin transaction outputs to be included as the last outputs in     |
-|                             |                | the coinbase transaction                                              |
+|                             |                | the coinbase transaction. An additional coinbase tx output (other than|
+|                             |                | the output which pays the fees + block subsidy), will most likely be  |
+|                             |                | the coinbase witness commitment output.                               |
+|                             |                |                                                                       |
 +-----------------------------+----------------+-----------------------------------------------------------------------+
 | coinbase_tx_locktime        | U32            | The locktime field in the coinbase transaction                        |
 +-----------------------------+----------------+-----------------------------------------------------------------------+


### PR DESCRIPTION
Adds a new field to the `NewTemplate` message to contain an optional 32 byte witness reserve value from the coinbase tx `scriptWitness` field. If the `NewTemplate` does not contain segwit inputs then we could simply just send 0 for the byte length or omit it entirely.

The witness reserve value is used for future extensions and is required to compute the witness commitment `SHA256^2(witness root, witness reserve value)`.

My current understanding is the witness reserve value is currently always set to `[0x00; 32]` but this may change with future use of this field.