### PR TITLE
Template Provider: remove the field coinbase_tx_outputs_count from NewTemplate

### DIFF
--- a/06-Template-Distribution-Protocol.md
+++ b/06-Template-Distribution-Protocol.md
@@ -62,8 +62,6 @@ The primary template-providing function. Note that the `coinbase_tx_outputs` byt
 |                             |                | added by the client. Includes both transaction fees and block         |
 |                             |                | subsidy.                                                              |
 +-----------------------------+----------------+-----------------------------------------------------------------------+
-| coinbase_tx_outputs_count   | U32            | The number of transaction outputs included in coinbase_tx_outputs     |
-+-----------------------------+----------------+-----------------------------------------------------------------------+
 | coinbase_tx_outputs         |SEQ0_64K[B0_64K]| Bitcoin transaction outputs to be included as the last outputs in     |
 |                             |                | the coinbase transaction                                              |
 +-----------------------------+----------------+-----------------------------------------------------------------------+


### PR DESCRIPTION
Optional optimization - not critical

Since #16 has been merged, it changes the `coinbase_tx_outputs` type to `SEQ0_64K[B0_64K]`. This means the field `coinbase_tx_outputs_count` becomes redundant since the number of coinbase transaction outputs can inferred using the first 2 bytes of `coinbase_tx_outputs (SEQ0_64K[B0_64K])`.

This means we drop 4 bytes  (coinbase_tx_outputs_count) and just use 2 bytes in `coinbase_tx_outputs` to infer the number of outputs.