### PR TITLE
Replace all `future_job` references with `min_ntime`

### DIFF
--- a/07-Template-Distribution-Protocol.md
+++ b/07-Template-Distribution-Protocol.md
@@ -76,7 +76,7 @@ The primary template-providing function. Note that the `coinbase_tx_outputs` byt
 
 ## 7.3 `SetNewPrevHash` (Server -> Client)
 Upon successful validation of a new best block, the server MUST immediately provide a `SetNewPrevHash` message.
-If a `NewWork` message has previously been sent with the `future_job` flag set, which is valid work based on the `prev_hash` contained in this message, the `template_id` field SHOULD be set to the `job_id` present in that `NewTemplate` message indicating the client MUST begin mining on that template as soon as possible.
+If a `NewWork` message has previously been sent with an empty `min_ntime`, which is valid work based on the `prev_hash` contained in this message, the `template_id` field SHOULD be set to the `job_id` present in that `NewTemplate` message indicating the client MUST begin mining on that template as soon as possible.
 
 TODO: Define how many previous works the client has to track (2? 3?), and require that the server reference one of those in `SetNewPrevHash`.
 


### PR DESCRIPTION
Addresses #20 to replace left over references to the deprecated `future_job` message field.