### PR TITLE
Add `invalid-job-id` error code in SubmitShares.error message

### DIFF
--- a/05-Mining-Protocol.md
+++ b/05-Mining-Protocol.md
@@ -290,6 +290,7 @@ Possible error codes:
 - `invalid-channel-id`
 - `stale-share`
 - `difficulty-too-low`
+- `invalid-job-id`
 
 ### 5.3.15 `NewMiningJob` (Server -> Client)
 


### PR DESCRIPTION
As suggested by @Fi3 [here](https://github.com/stratum-mining/stratum/pull/727#discussion_r1462190704) I open this PR to add the error code `invalid-job-id` I introduced in [PR #727](https://github.com/stratum-mining/stratum/pull/727).
It is mainly used in cases where the miner sends a share right after a new job is created and sent to it.