### PR TITLE
Add stale-template-id error code in RequestTransactionData.Error message

### DIFF
--- a/07-Template-Distribution-Protocol.md
+++ b/07-Template-Distribution-Protocol.md
@@ -96,8 +96,8 @@ To work around the limitation of not being able to negotiate e.g. a transaction 
 
 Possible error codes:
 
-- `template-id-not-found`
-- `stale-template-id`
+- `template-id-not-found` - used when the template being referenced is too old and no longer stored in the memory of the Template Provider
+- `stale-template-id` - used when the prev_hash of the corresponding template is still in the Template Provider's memory, but it no longer points to the latest tip 
 
 ## 7.7 `SubmitSolution` (Client -> Server)
 

--- a/07-Template-Distribution-Protocol.md
+++ b/07-Template-Distribution-Protocol.md
@@ -97,6 +97,7 @@ To work around the limitation of not being able to negotiate e.g. a transaction 
 Possible error codes:
 
 - `template-id-not-found`
+- `stale-template-id`
 
 ## 7.7 `SubmitSolution` (Client -> Server)
 


### PR DESCRIPTION
After a deep discussion we had at https://github.com/stratum-mining/stratum/issues/709, we agreed on adding a new error code in RequestTransactionData.Error message called `stale-template-id`.
This error code will be used by JDC to better manage the cases in which it sends a RequestTransactionData message for a stale template to TP.