### PR TITLE
closes #59 feature: redefine payload length to indicate plaintext length

### DIFF
--- a/04-Protocol-Security.md
+++ b/04-Protocol-Security.md
@@ -321,12 +321,15 @@ uint pt_len_to_ct_len(uint pt_len) {
 }
 ```
 
+
 - Note: The `message_length` (payload_length) in the encrypted Stratum message header always reflects the plaintext payload size. The size of the encrypted payload is implicitly understood to be message_length + MAC size for each block. This simplifies the decryption process and ensures clarity in interpreting frame data.
 
 #### Decrypting stratum message
 1. read exactly 22 bytes and decrypt into stratum frame or fail
-2. read `frame.message_length` number of bytes (as specified in the decrypted header) and decrypt them into plaintext payload. If decryption fails, the process stops.
+2.The value `frame.message_length` should first be converted to the ciphertext length, and then that amount of data should be read and decrypted into plaintext payload. If decryption fails, the process stops
 3. deserialize plaintext payload into stratum message given by `frame.extension_type` and `frame.message_type` or fail
+
+
 
 #### Encrypted stratum message frame layout
 ```

--- a/04-Protocol-Security.md
+++ b/04-Protocol-Security.md
@@ -305,6 +305,14 @@ Stratum Message header and stratum message payload are processed separately.
    5. `EncryptWithAd([], payload)` - variable length encrypted message
 4. concatenate resulting header and payload ciphertext
 
+- Note: The `message_length` (payload_length) in the encrypted Stratum message header always reflects the plaintext payload size. The size of the encrypted payload is implicitly understood to be message_length + MAC size for each block. This simplifies the decryption process and ensures clarity in interpreting frame data.
+
+#### Decrypting stratum message
+1. read exactly 22 bytes and decrypt into stratum frame or fail
+2.The value `frame.message_length` should first be converted to the ciphertext length, and then that amount of data should be read and decrypted into plaintext payload. If decryption fails, the process stops
+3. deserialize plaintext payload into stratum message given by `frame.extension_type` and `frame.message_type` or fail
+
+
 *converting plaintext length to ciphertext length:
 ```c
 #define MAX_CT_LEN 65535
@@ -320,15 +328,6 @@ uint pt_len_to_ct_len(uint pt_len) {
         return pt_len / MAX_PT_LEN * MAX_CT_LEN + remainder;
 }
 ```
-
-
-- Note: The `message_length` (payload_length) in the encrypted Stratum message header always reflects the plaintext payload size. The size of the encrypted payload is implicitly understood to be message_length + MAC size for each block. This simplifies the decryption process and ensures clarity in interpreting frame data.
-
-#### Decrypting stratum message
-1. read exactly 22 bytes and decrypt into stratum frame or fail
-2.The value `frame.message_length` should first be converted to the ciphertext length, and then that amount of data should be read and decrypted into plaintext payload. If decryption fails, the process stops
-3. deserialize plaintext payload into stratum message given by `frame.extension_type` and `frame.message_type` or fail
-
 
 
 #### Encrypted stratum message frame layout

--- a/04-Protocol-Security.md
+++ b/04-Protocol-Security.md
@@ -299,8 +299,8 @@ Stratum Message header and stratum message payload are processed separately.
 
 #### Encrypting stratum message
 1. serialize stratum message into a plaintext binary string (payload)
-2. prepare frame header for the stratum message with `message_length` being length of payload ciphertext*
-3. Encrypt and concatenate serialized header and payload:
+2. prepare the frame header for the Stratum message `message_length` is the length of the plaintext payload.
+3. encrypt and concatenate serialized header and payload:
    4. `EncryptWithAd([], header)` - 22 bytes
    5. `EncryptWithAd([], payload)` - variable length encrypted message
 4. concatenate resulting header and payload ciphertext
@@ -321,9 +321,11 @@ uint pt_len_to_ct_len(uint pt_len) {
 }
 ```
 
+- Note: The `message_length` (payload_length) in the encrypted Stratum message header always reflects the plaintext payload size. The size of the encrypted payload is implicitly understood to be message_length + MAC size for each block. This simplifies the decryption process and ensures clarity in interpreting frame data.
+
 #### Decrypting stratum message
 1. read exactly 22 bytes and decrypt into stratum frame or fail
-2. read `frame.message_length` number of bytes and decrypt into plaintext payload or fail
+2. read `frame.message_length` number of bytes (as specified in the decrypted header) and decrypt them into plaintext payload. If decryption fails, the process stops.
 3. deserialize plaintext payload into stratum message given by `frame.extension_type` and `frame.message_type` or fail
 
 #### Encrypted stratum message frame layout
@@ -341,6 +343,7 @@ uint pt_len_to_ct_len(uint pt_len) {
 | U16            | U8       | U24        |   ing>  | 65519 B   |  ing> | 65519 B   |  ing> | 1 - 65519 B   |           |
 +----------------+----------+------------+---------+-------------------------------------------------------------------+
 
+The `pld_length` field in the Encrypted Stratum message Header now consistently represents the plaintext length of the payload.
 Serialized stratum-v2 body (payload) is split into 65519-byte chunks and encrypted to form 65535-bytes AEAD ciphertexts,
 where `ct_pld_N` is the N-th ciphertext block of payload and `pt_pld_N` is the N-th plaintext block of payload.
 ```


### PR DESCRIPTION
### What does this PR do?
- This PR offers clarification in the framing and noise-encryption specification so that the meaning of payload_length to always stand for plaintext length - even in the encrypted header

### Problem Statement
In the current Stratum v2 specification, the Frame structure, which consists of a Header and a Payload, defines payload_length as the length of the ciphertext payload. This creates an ambiguity in frame interpretation. After decrypting a frame, it's unclear whether the resulting data is a direct decryption of a valid frame or an incorrectly formatted frame.

### Proposed Changes
I propose to redefine the payload_length field in the Frame structure to always represent the plaintext length, even in the encrypted header. The encrypted Frame will consist of:

```An encrypted Header, where payload_length denotes the plain-text length.
The encrypted Payload.
This change will clarify the frame structure and remove ambiguity in frame interpretation.
```
### Rationale
The proposed change ensures that the meaning of payload_length is consistent and unambiguous, whether dealing with encrypted or plain-text frames. By always referring to the plain-text length, it becomes straightforward for the receiving and decrypting side to understand the expected cipher text length to be read after decrypting the header.

#### Examples

##### Current Specification:

Given a frame with payload_length: 5, the encrypted frame's payload_length becomes 21 bytes (5 bytes of payload + 16 bytes MAC).
##### Proposed Specification:

The frame's payload_length always reflects the plain-text payload size. The encrypted payload size is implicitly understood to be payload_length + MAC size.

### Impact Analysis
This change primarily affects the frame serialisation and parsing logic. Implementations will need to adjust the way they calculate payload_length during encryption and decryption processes. The proposed change is expected to enhance clarity and reduce potential errors in implementation without significantly impacting existing functionalities.
