### PR TITLE
Add pool port to URL example.

### DIFF
--- a/04-Protocol-Security.md
+++ b/04-Protocol-Security.md
@@ -402,7 +402,7 @@ URL example:
 
 ```
 
-stratum2+tcp://thepool.com:3334/9bXiEd8boQVhq7WddEcERUL5tyyJVFYdU8th3HfbNXK3Yw6GRXh
+stratum2+tcp://thepool.com:34254/9bXiEd8boQVhq7WddEcERUL5tyyJVFYdU8th3HfbNXK3Yw6GRXh
 
 ```
 

--- a/04-Protocol-Security.md
+++ b/04-Protocol-Security.md
@@ -402,7 +402,7 @@ URL example:
 
 ```
 
-stratum2+tcp://thepool.com/9bXiEd8boQVhq7WddEcERUL5tyyJVFYdU8th3HfbNXK3Yw6GRXh
+stratum2+tcp://thepool.com:3334/9bXiEd8boQVhq7WddEcERUL5tyyJVFYdU8th3HfbNXK3Yw6GRXh
 
 ```
 


### PR DESCRIPTION
Adds a port to the pool URL example.

Curious if there is an expected default port?  I haven't seen one anywhere, but it might be a good idea to specify it here if it exists, or maybe define one if not.