### PR TITLE
protocol version must be 2 in `SetupConnection` message

### DIFF
--- a/03-Protocol-Overview.md
+++ b/03-Protocol-Overview.md
@@ -164,13 +164,13 @@ However, they MUST always set vendor to a string describing the manufacturer/dev
 
 | Field Name         | Data Type | Description                                                                                                                 |
 |--------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------|
-| protocol           | U8        | 0 = Mining Protocol <br>1 = Job Declaration <br>2 = Template Distribution Protocol <br> 3 = Job Distribution Protocol        |
-| min_version        | U16       | The minimum protocol version the client supports (currently must be 3)                                                      |
-| max_version        | U16       | The maximum protocol version the client supports (currently must be 3)                                                      |
+| protocol           | U8        | 0 = Mining Protocol <br>1 = Job Declaration <br>2 = Template Distribution Protocol <br> 3 = Job Distribution Protocol       |
+| min_version        | U16       | The minimum protocol version the client supports (currently must be 2)                                                      |
+| max_version        | U16       | The maximum protocol version the client supports (currently must be 2)                                                      |
 | flags              | U32       | Flags indicating optional protocol features the client supports. Each protocol from protocol field as its own values/flags. |
 | endpoint_host      | STRO_255  | ASCII text indicating the hostname or IP address                                                                            |
 | endpoint_port      | U16       | Connecting port value                                                                                                       |
-| Device Information |
+| Device Information |           |                                                                                                                             |
 | vendor             | STR0_255  | E.g. "Bitmain"                                                                                                              |
 | hardware_version   | STR0_255  | E.g. "S9i 13.5"                                                                                                             |
 | firmware           | STR0_255  | E.g. "braiins-os-2018-09-22-1-hash"                                                                                         |


### PR DESCRIPTION
there is a protocol version missmatch between `SetupConnection` [here](https://github.com/stratum-mining/stratum/blob/7841021e3f20280c62af119de5de58f421c6e428/protocols/v2/subprotocols/common-messages/src/setup_connection.rs#L32-L35) and the specs, i guess the typo is on spec side.