### PR TITLE
Fix minor typos

### DIFF
--- a/04-Protocol-Security.md
+++ b/04-Protocol-Security.md
@@ -45,7 +45,7 @@ encoding as defined in BIP 340.<sup>[3](#reference-3)</sup>.
 2. When sharing keys during the handshake, whether in plain text or encrypted,
 we use the 64 byte ElligatorSwift x-only encoding as defined in BIP324<sup>[7](#reference-7)</sup> under "ElligatorSwift encoding of curve X coordinates". This encoding uses 64-bytes instead of 32-bytes in order to produce a
 pseudo-random bytesteam. This is useful because the protocol handshake starts with
-each side sending ther public key in plain text. Additionally the use of X-only
+each side sending their public key in plain text. Additionally the use of X-only
 ElligatorSwift ECDH removes the need to grind or negate private keys.
 
 3. The Authority public key is base58-check encoded as described in 4.7.

--- a/10-Discussion.md
+++ b/10-Discussion.md
@@ -70,7 +70,7 @@ The proxy:
 ...
 
 
-## 10.5. FAQ
+## 10.5 FAQ
 
 
 ### 10.5.1 Why is the protocol binary?


### PR DESCRIPTION
Really just run on two infinitesimal typos as I was reading to learn more about how the protocol works.