### PR TITLE
re-introduce `min_ntime` to `SetCustomMiningJob` (now as non-optional)

### DIFF
--- a/05-Mining-Protocol.md
+++ b/05-Mining-Protocol.md
@@ -470,6 +470,7 @@ The `mining_job_token` provides the information for the pool to authorize the cu
 | coinbase_tx_outputs         | B0_64K         | Bitcoin transaction outputs to be included as the last outputs in the coinbase transaction                                                                            |
 | coinbase_tx_locktime        | U32            | The locktime field in the coinbase transaction                                                                                                                        |
 | merkle_path                 | SEQ0_255[U256] | Merkle path hashes ordered from deepest                                                                                                                               |
+| min_ntime                   | u32    | Smallest nTime value available for hashing.                                                                                                                                   |
 
 ### 5.3.19 `SetCustomMiningJob.Success` (Server -> Client)
 


### PR DESCRIPTION
close #128 
follow-up to #121

`SetCustomMiningJob` cannot ever be future job.

on 0fd5cf5d50ed0aa10339c3a676496acf536af94c we completely dropped this field, which is not correct.

while field field cannot be optional, it cannot be dropped... it needs to be mandatory

otherwise pool could reward work for custom jobs on timestamps that are in the past (which would lead to rejected blocks)