### PR TITLE
fixes cross-compatibility issue of `generate-readme.sh`

### DIFF
--- a/scripts/generate-readme.sh
+++ b/scripts/generate-readme.sh
@@ -19,15 +19,18 @@ for file in $(ls *.md | grep -v -i 'README.md' | sort); do
             number="${BASH_REMATCH[2]}"
             title="${BASH_REMATCH[5]}"
             level=$((${#hashes} - 1))
-            indent=$(printf ' %.0s' $(seq 1 $((level * 2))))
+            indent=$(printf '%*s' $((level * 2)) " ")
             anchor=$(echo "$number-$title" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -cd '[:alnum:]-')
             echo "${indent}- [$number. $title](./$file#$anchor)" >> "$INDEX_TMP"
         fi
     done < "$file"
 done
 
-# Generate the new README content
-awk -v table_of_contents="$(cat $INDEX_TMP)" '{gsub(/\[table_of_contents\]/, table_of_contents)}1' "$TEMPLATE" > "$README_TMP"
+# Replace [table_of_contents] with generated index
+sed "/\[table_of_contents\]/{
+    r $INDEX_TMP
+    d
+}" "$TEMPLATE" > "$README_TMP"
 
 if [[ "$1" == "--check" ]]; then
     if ! diff --color=auto -u "$OUTFILE" "$README_TMP"; then
@@ -47,3 +50,4 @@ else
     rm "$INDEX_TMP" "$README_TMP"
     echo -e "${GREEN}No changes made. Use --check to verify or --bless to update README.md.${NC}"
 fi
+

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -1,0 +1,22 @@
+
+# README Generator Script
+
+This `generate-readme.sh` script updates `README.md` by generating a Table of Contents (ToC) from all Markdown files in the repository.
+It replaces the `[table_of_contents]` placeholder in `README.template.md` with the generated index.
+
+## Usage
+
+```bash
+./scripts/generate-readme.sh [option]
+```
+
+Options:
+
+* `--check` : verify if `README.md` is up to date (exit 1 if not).
+* `--bless` : regenerate and overwrite `README.md`.
+
+## Notes
+
+* `README.template.md` must contain `[table_of_contents]`.
+* Run `--check` before committing to ensure the ToC is current.
+


### PR DESCRIPTION
closes #154 

This PR replaces `awk` with `sed` in `generate-readme.sh`.
The default `awk` on macOS behaves differently from Linux, which caused inconsistent results when generating the README. Using `sed` ensures consistent behavior across systems.

Additionally, a `README.md` was added to the `scripts/` folder to document the purpose and usage of the script.