### PR TITLE
allow Group Channels to contain Extended Channels

### DIFF
--- a/05-Mining-Protocol.md
+++ b/05-Mining-Protocol.md
@@ -182,7 +182,7 @@ The size of search space for an Extended Channel is `2^(nonce_bits + version_rol
 Mining and/or Standard Channels opened within one particular connection can be grouped together to be addressable by a common communication group channel.
 
 Every mining channel is a member of a group identified by its `group_channel_id`.
-Group Channel ID namespace is the same as Mining Channel ID namespace on a particular connection.
+Group Channel ID namespace is the same as Mining Channel ID namespace on a particular connection. In other words, there must never be a Group Channel whose `group_channel_id` is identical to some `channel_id` of some Standard or Extended Channel within the context of the same connection.
 
 All channels under the same Group Channel (Extended and Standard) MUST have the exact same size for the full Extended Extranonce (`extranonce_prefix` for Standard Channels, or `extranonce_prefix` + `extranonce` for Extended Channels).
 


### PR DESCRIPTION
based on https://github.com/stratum-mining/sv2-spec/discussions/157

this PR is modifying the Sv2 Spec so that Group Channels can also contain Extended Channels

most changes should be (relatively) backward compatible, with one exception:

`OpenExtendedMiningChannel.Success` now has a new field `group_channel_id`