### PR TITLE
Fix a typo

### DIFF
--- a/04-Protocol-Security.md
+++ b/04-Protocol-Security.md
@@ -9,7 +9,7 @@ At the same time, this specification proposes optional use of a particular hands
 The client and server establish secure communication using Diffie-Hellman (DH) key agreement, as described in greater detail in the Authenticated Key Agreement Handshake section below.
 
 Using the handshake protocol to establish secured communication is **optional** on the local network (e.g. local mining devices talking to a local mining proxy).
-However, it is **mandatory** for remote access to the upstream nodes, whether they be pool mining services, job declarating services or template distributors.
+However, it is **mandatory** for remote access to the upstream nodes, whether they be pool mining services, job declaring services or template distributors.
 
 ## 4.1 Motivation for Authenticated Encryption with Associated Data
 


### PR DESCRIPTION
Same explanation as in https://github.com/stratum-mining/sv2-spec/pull/176

**PLEASE DO NOT MERGE**
This PR fixes a small typo.

I will be sending several small PR typo fixes in this repo, as part of the new website PR https://github.com/stratum-mining/stratumprotocol.org/pull/300

The new website, just like the current one uses sv2-specs repo as a submodule, and whenever there's a marge in this repo, it SHOULD trigger a workflow which updates the submodule and rebuilds the website, so we always have stratumprotocol.com/specification page 1:1 as sv2-specs repo.

I'll be making several smaller PR's so we can test if workflows work good, will give green light when these are good to go one by one.