### PR TITLE
Fix reference links in specification by adding href attributes

### DIFF
--- a/04-Protocol-Security.md
+++ b/04-Protocol-Security.md
@@ -417,11 +417,10 @@ prefixed_base58check = "9bXiEd8boQVhq7WddEcERUL5tyyJVFYdU8th3HfbNXK3Yw6GRXh"
 
 ## 4.8 References
 
-1. <a id="reference-1"> https://web.cs.ucdavis.edu/~rogaway/papers/ad.pdf</a>
-2. <a id="reference-2"> https://www.secg.org/sec2-v2.pdf</a>
-3. <a id="reference-3"> https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki</a>
-4. <a id="reference-4"> https://tools.ietf.org/html/rfc8439</a>
-5. <a id="reference-5"> https://www.ietf.org/rfc/rfc2104.txt</a>
-6. <a id="reference-6"> https://tools.ietf.org/html/rfc5869</a>
-7. <a id="reference-7"> https://github.com/bitcoin/bips/blob/master/bip-0324.mediawiki</a>
-```
+1. <a id="reference-1" href="https://web.cs.ucdavis.edu/~rogaway/papers/ad.pdf">https://web.cs.ucdavis.edu/~rogaway/papers/ad.pdf</a>
+2. <a id="reference-2" href="https://www.secg.org/sec2-v2.pdf">https://www.secg.org/sec2-v2.pdf</a>
+3. <a id="reference-3" href="https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki">https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki</a>
+4. <a id="reference-4" href="https://tools.ietf.org/html/rfc8439">https://tools.ietf.org/html/rfc8439</a>
+5. <a id="reference-5" href="https://www.ietf.org/rfc/rfc2104.txt">https://www.ietf.org/rfc/rfc2104.txt</a>
+6. <a id="reference-6" href="https://tools.ietf.org/html/rfc5869">https://tools.ietf.org/html/rfc5869</a>
+7. <a id="reference-7" href="https://github.com/bitcoin/bips/blob/master/bip-0324.mediawiki">https://github.com/bitcoin/bips/blob/master/bip-0324.mediawiki</a>


### PR DESCRIPTION
add missing href, and remove stray code fence that caused https://stratumprotocol.org/specification/04-protocol-security/#48-references to be rendered incorrectly since it wasn't according to markdown standards.

Related #176 